### PR TITLE
Fix workflow permission

### DIFF
--- a/.github/workflows/build_version_tag.yaml
+++ b/.github/workflows/build_version_tag.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/delete_version_tags.yaml
+++ b/.github/workflows/delete_version_tags.yaml
@@ -6,6 +6,8 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
jobにwrite権限をつけないとリポジトリ操作ができないようだったので追加しました。

https://docs.github.com/ja/actions/using-jobs/assigning-permissions-to-jobs