### PR TITLE
Fix newline echo

### DIFF
--- a/.github/scripts/version/get_versions.sh
+++ b/.github/scripts/version/get_versions.sh
@@ -11,7 +11,7 @@ echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 TAG_VERSION=$(git tag | grep '^v[0-9]*\.[0-9]*\.[0-9]*' | sort -V | tail -n 1 | sed 's/^v//')
 echo "TAG_VERSION=$TAG_VERSION" >> $GITHUB_OUTPUT
 
-NEWER_VERSION=$(echo "$VERSION\n$TAG_VERSION" | sort -V | tail -n 1)
+NEWER_VERSION=$(echo -e "$VERSION\n$TAG_VERSION" | sort -V | tail -n 1)
 IS_VERSION_UPDATED="true"
 if [ "$TAG_VERSION" = "$NEWER_VERSION" ]; then
     IS_VERSION_UPDATED="false"


### PR DESCRIPTION
echoで改行を有効にするには`-e`オプションが必要だったため修正しました。